### PR TITLE
support customized k3s image

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The application performs the following steps to accomplish this
 
 ## Installation
 ``` bash
-go install github.com/kevinjoiner/crd-swagger
+go install github.com/KevinJoiner/crd-swagger
 ```
 
 ### Requirements
@@ -28,6 +28,7 @@ Usage:
 
 Flags:
       --cluster-port string   port to bind kubeapi-server to on the host machine (default "6443")
+      --cluster-image string  image to deploy k3s (default "rancher/k3s:v1.27.5-k3s1")
   -f, --files string          location to find input CRD file/files, either a file path or a remote URL
   -h, --help                  help for crd-swagger
   -o, --output-file string    location to output the generate swagger doc (if unset stdout is used)

--- a/pkg/cmd/cluster.go
+++ b/pkg/cmd/cluster.go
@@ -27,8 +27,8 @@ import (
 )
 
 const (
-	defaultK3sPort = "6443"
-	k3sImage       = "rancher/k3s:v1.27.5-k3s1"
+	defaultK3sPort  = "6443"
+	defaultK3sImage = "rancher/k3s:v1.27.5-k3s1"
 )
 
 type dockerCluster struct {
@@ -90,7 +90,7 @@ func (d *dockerCluster) stop(ctx context.Context) error {
 func (d *dockerCluster) pullK3sImage(ctx context.Context) error {
 	timeoutCtx, cancel := context.WithTimeout(ctx, requestTimeout)
 	defer cancel()
-	reader, err := d.cli.ImagePull(timeoutCtx, k3sImage, types.ImagePullOptions{})
+	reader, err := d.cli.ImagePull(timeoutCtx, cmdFlags.k3sImage, types.ImagePullOptions{})
 	if err != nil {
 		return fmt.Errorf("failed to pull image: %w", err)
 	}
@@ -110,7 +110,7 @@ func (d *dockerCluster) createContainer(ctx context.Context) error {
 	defer cancel()
 	resp, err := d.cli.ContainerCreate(timeoutCtx,
 		&container.Config{
-			Image:      k3sImage,
+			Image:      ,
 			Entrypoint: []string{"/bin/k3s", "server"},
 			ExposedPorts: nat.PortSet{
 				defaultK3sPort: struct{}{},

--- a/pkg/cmd/cluster.go
+++ b/pkg/cmd/cluster.go
@@ -110,7 +110,7 @@ func (d *dockerCluster) createContainer(ctx context.Context) error {
 	defer cancel()
 	resp, err := d.cli.ContainerCreate(timeoutCtx,
 		&container.Config{
-			Image:      ,
+			Image:      cmdFlags.k3sImage,
 			Entrypoint: []string{"/bin/k3s", "server"},
 			ExposedPorts: nat.PortSet{
 				defaultK3sPort: struct{}{},

--- a/pkg/cmd/cmd.go
+++ b/pkg/cmd/cmd.go
@@ -35,6 +35,7 @@ type flagVar struct {
 	prettyPrint bool
 	recurse     bool
 	silent      bool
+	k3sImage    string
 }
 
 var (
@@ -85,6 +86,7 @@ func addFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolVarP(&cmdFlags.prettyPrint, "pretty-print", "p", false, "print the output json with formatted with newlines and indentations")
 	cmd.Flags().StringVar(&cmdFlags.k3sPort, "cluster-port", defaultK3sPort, "port to bind kubeapi-server to on the host machine")
 	cmd.Flags().BoolVar(&cmdFlags.silent, "silent", false, "do not print any log messages")
+	cmd.Flags().StringVar(&cmdFlags.k3sImage, "cluster-image", defaultK3sImage, "image to deploy k3s")
 	_ = cmd.MarkFlagRequired("files")
 }
 


### PR DESCRIPTION
1. support customized k3s image for private docker image source
2. reconcile package name in go get command in README.md to that in go.mod